### PR TITLE
Disable schema options when using custom restore format

### DIFF
--- a/PgBackupRestoreTool.csproj
+++ b/PgBackupRestoreTool.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.2</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+      <OutputType>WinExe</OutputType>
+      <TargetFramework>net8.0-windows</TargetFramework>
+      <Nullable>enable</Nullable>
+      <UseWindowsForms>true</UseWindowsForms>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Version>1.0.3</Version>
+      <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      <FileVersion>1.0.0.0</FileVersion>
+    </PropertyGroup>
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/frmMain.Designer.cs
+++ b/frmMain.Designer.cs
@@ -253,18 +253,20 @@ namespace PgBackupRestoreTool
             radioRestorePlain.TabIndex = 5;
             radioRestorePlain.TabStop = true;
             radioRestorePlain.Text = "Plain SQL (.sql)";
-            // 
+            radioRestorePlain.CheckedChanged += RestoreFormatChanged;
+            //
             // radioRestoreCustom
-            // 
+            //
             radioRestoreCustom.AutoSize = true;
             radioRestoreCustom.Location = new Point(301, 66);
             radioRestoreCustom.Name = "radioRestoreCustom";
             radioRestoreCustom.Size = new Size(134, 19);
             radioRestoreCustom.TabIndex = 6;
             radioRestoreCustom.Text = "Custom format (-F c)";
-            // 
+            radioRestoreCustom.CheckedChanged += RestoreFormatChanged;
+            //
             // labelSchema
-            // 
+            //
             labelSchema.AutoSize = true;
             labelSchema.Location = new Point(10, 103);
             labelSchema.Name = "labelSchema";

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -68,6 +68,18 @@ namespace PgBackupRestoreTool
             checkBoxDrop.Enabled = enable;
         }
 
+        private void RestoreFormatChanged(object? sender, EventArgs e)
+        {
+            bool isPlain = radioRestorePlain.Checked;
+            comboBoxSchema.Enabled = isPlain && comboBoxSchema.Items.Count > 0;
+            ComboBoxSchema_SelectedIndexChanged(null, EventArgs.Empty);
+            if (!isPlain)
+            {
+                checkBoxClean.Checked = false;
+                checkBoxDrop.Checked = false;
+            }
+        }
+
         private void EnableAbort(bool enable)
         {
             if (buttonAbort.InvokeRequired)
@@ -553,6 +565,7 @@ namespace PgBackupRestoreTool
                     checkBoxDrop.Enabled = false;
                     Log("No schema found.", Color.Orange);
                 }
+                RestoreFormatChanged(null, EventArgs.Empty);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- avoid enabling schema clean/drop options when the custom restore format is selected
- update version to v1.0.3

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892a8b49ee8833089384c53f89f72f6